### PR TITLE
Add more params: datapoints_to_alarm and actions_enabled

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,11 @@ variable "default_evaluation_periods" {
   default     = 2
 }
 
+variable "default_datapoints_to_alarm" {
+  description = "The default amount of datapoints to alarm."
+  default     = 2
+}
+
 variable "default_period" {
   description = "The default evaluation period."
   default     = 60
@@ -21,6 +26,11 @@ variable "default_comparison_operator" {
 variable "default_statistic" {
   description = "The default statistic."
   default     = "Average"
+}
+
+variable "default_actions_enabled" {
+  description = "Indicates whether or not actions should be executed during any changes to the alarm's state."
+  default     = true
 }
 
 resource "aws_cloudwatch_metric_alarm" "alarm" {
@@ -42,6 +52,12 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
     var.alarms[element(keys(var.alarms), count.index)],
     "evaluation_periods",
     var.default_evaluation_periods
+  )
+
+  datapoints_to_alarm = lookup(
+    var.alarms[element(keys(var.alarms), count.index)],
+    "datapoints_to_alarm",
+    var.default_datapoints_to_alarm
   )
 
   metric_name = element(keys(var.alarms), count.index)
@@ -75,5 +91,11 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
     var.alarms[element(keys(var.alarms), count.index)],
     "actions",
     ""
+  )))
+
+  actions_enabled = compact(split(",", lookup(
+    var.alarms[element(keys(var.alarms), count.index)],
+    "actions_enabled",
+    var.default_actions_enabled
   )))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,9 @@ The following arguments are supported:
   - period: The period in seconds over which the specified statistic is applied.
   - statistic: The statistic to apply to the alarm's associated metric.
   - threshold: The number of occurances over a given period.
+  - datapoints_to_alarm: The number of datapoints that must be breaching to trigger the alarm.
   - actions: The actions to execute when the alarm transitions into an ALARM state.
       Due to a limitation in Terraform, this list must be given as a comma-separated string.
+  - actions_enabled: Indicates whether or not actions should be executed during any changes to the alarm's state.
 EOF
 }


### PR DESCRIPTION
@betabandido Can you please take a look?

We need to set some more params on `aws_cloudwatch_metric_alarm`.